### PR TITLE
Replace Invoke-Expression with call operator in CSV generation

### DIFF
--- a/codeql-analysis/action.yml
+++ b/codeql-analysis/action.yml
@@ -152,7 +152,7 @@ runs:
           codeql database interpret-results $Path --format=csv --output="$CSVPath"
         } else {
           $CodeQLCommand = "$((Get-ChildItem $Env:RUNNER_TOOL_CACHE\CodeQL\*\x64\codeql\codeql.exe).fullname | Select-Object -first 1)"
-          Invoke-Expression "$CodeQLCommand database interpret-results $Path --format=csv --output='$CSVPath'"
+          & $CodeQLCommand database interpret-results $Path --format=csv --output='$CSVPath'
         }
       env:
         language: ${{ inputs.language }}


### PR DESCRIPTION
For Windows runners, the "Generate CodeQL Results CSV" step can encounter an issue when it tries to use the path to the `codeql` command.

If there's a space in `$CodeQLCommand` (e.g. `C:\Program Files\...`), `Invoke-Expression` won't be able to parse it.

Some output of a failing actions run that demonstrates this:

```
  $Language = "$Env:language"
  $Path = "$Env:path"
  $Temp = "$Env:temp"
  $CSVPath = "$Temp\codeql-scan-results-$Env:language.csv"
  if (Get-Command codeql -errorAction SilentlyContinue) {
    codeql database interpret-results $Path --format=csv --output="$CSVPath"
  } else {
    $CodeQLCommand = "$((Get-ChildItem $Env:RUNNER_TOOL_CACHE\CodeQL\*\x64\codeql\codeql.exe).fullname | Select-Object -first 1)"
    Invoke-Expression "$CodeQLCommand database interpret-results $Path --format=csv --output='$CSVPath'"
  }
  shell: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE -command ". '{0}'"
  env:
    ...
Missing required options [--format=<format>, --output=<output>]
Try codeql database interpret-results --help for usage help.
Invoke-Expression : The term 'C:\Program' is not recognized as the name of a cmdlet, function, script file, or 
operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try 
again.
At D:\a\_temp\8541400d-c6f4-4d32-a70e-809414fc4d8c.ps1:10 char:3
+   Invoke-Expression "$CodeQLCommand database interpret-results $Path  ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Program:String) [Invoke-Expression], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```
(here's the full run: https://github.com/department-of-veterans-affairs/cdsp-com-object/actions/runs/5338201269/jobs/9675245477?pr=3)

Powershell documentation recommends replacing Invoke-Expression with the call operator ("&"), which handles this.

see: https://devblogs.microsoft.com/powershell/invoke-expression-considered-harmful/