### PR TITLE
force lower case of language for the mappedLanguages

### DIFF
--- a/collect-metrics/internal/github_utils.go
+++ b/collect-metrics/internal/github_utils.go
@@ -36,7 +36,7 @@ func CalculateMissingLanguages(expectedLanguages, actualLanguages []string) []st
 func MapLanguages(languages map[string]int) []string {
 	mappedLanguages := make([]string, len(languages))
 	for language := range languages {
-		switch language {
+		switch strings.ToLower(language) {
 		case "c":
 		case "c++":
 			mappedLanguages = append(mappedLanguages, "cpp")


### PR DESCRIPTION
Make sure the language is lower case so the mapping of languages works as expected.