### PR TITLE
Create shared libraries to allow Jenkins users to execute CodeQL as part of their standard CI process

### DIFF
--- a/.github/jenkins/linux/Jenkinsfile
+++ b/.github/jenkins/linux/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
                 cleanWs()
                 checkout scm
                 withCredentials([string(credentialsId: 'github-token', variable: 'TOKEN')]) {
+                    sh "env | sort"
                     ExecuteCodeQL('department-of-veterans-affairs', 'codeql-tools', env.GIT_BRANCH, 'javascript', '', env.TOKEN, true)
                 }
                 sh "mv codeql-scan-results-javascript.csv codeql-scan-results-javascript-linux.csv"
@@ -26,6 +27,7 @@ pipeline {
                 checkout scm
                 dir('verify-scans') {
                     withCredentials([string(credentialsId: 'github-token', variable: 'TOKEN')]) {
+                        sh "env | sort"
                         ExecuteCodeQL('department-of-veterans-affairs', 'codeql-tools', env.GIT_BRANCH, 'javascript', '', env.TOKEN, true)
                     }
                     sh "mv codeql-scan-results-javascript.csv codeql-scan-results-javascript-linux-subdir.csv"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
+codeql/
 node_modules/
 tmp/
 
 configure-codeql/pull-request-body.txt
 script.sh
 test.js
+test.sh
 
 **/.env
 **/.envrc

--- a/jenkins/shared-libraries/linux/vars/AnalyzeCodeQLDatabase.groovy
+++ b/jenkins/shared-libraries/linux/vars/AnalyzeCodeQLDatabase.groovy
@@ -1,0 +1,72 @@
+def call(repo, language) {
+    env.DATABASE_BUNDLE = sprintf("%s-database.zip", language)
+    env.DATABASE_PATH = sprintf("%s-%s", repo, language)
+    if(!env.ENABLE_DEBUG) {
+        env.ENABLE_DEBUG = false
+    }
+    if(!env.ENABLE_CODEQL_DEBUG) {
+        env.ENABLE_CODEQL_DEBUG = false
+    }
+    env.LANGUAGE = language.toLowerCase()
+    if(["javascript" , "python", "ruby"].contains(env.LANGUAGE)) {
+        env.COMPILED_LANGUAGE = false
+    } else {
+        env.COMPILED_LANGUAGE = true
+    }
+    env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
+    env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-and-quality.qls", language, language)
+
+    sh """
+        if [ "${ENABLE_DEBUG}" = true ]; then
+            set -x
+        else
+            set +x
+        fi
+
+        command="codeql"
+        if [ ! -x "\$(command -v \$command)" ]; then
+            echo "CodeQL CLI not found on PATH, checking if local copy exists"
+            if [ ! -f "${WORKSPACE}/codeql/codeql" ]; then
+                echo "CodeQL CLI not found in local copy, please add the CodeQL CLI to your PATH or use the 'InstallCodeQL' command to download it"
+                exit 1
+            fi
+            echo "Using local copy of CodeQL CLI"
+            command="${WORKSPACE}/codeql/codeql"
+        fi
+
+        if [ "${BUILD_COMMAND}" = "" ] && [ "${COMPILED_LANGUAGE}" = true ]; then
+            echo "Finalizing database"
+            "\$command" database finalize "${DATABASE_PATH}"
+            echo "Database finalized"
+        fi
+
+        echo "Checking if current working directory and Jenkins workspace are the same directory"
+        if [ "\${PWD}" = "${WORKSPACE}" ]; then
+            echo "The current working directory and Jenkins workspace match"
+            SUBDIR=''
+            SEP=''
+        else
+            echo "The current working directory and Jenkins workspace do not match, updating the SARIF category value to deduplicate Code Scanning results"
+            SUBDIR=\$( echo \${PWD} | awk -F'/' '{print \$NF}' )
+            SEP='-'
+        fi
+        echo "The SARIF category has been configured to ois-${LANGUAGE}\${SEP}\${SUBDIR}"
+
+        echo "Analyzing database"
+        "\$command" database analyze "${DATABASE_PATH}" --no-download --threads 0 --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
+        echo "Database analyzed"
+
+        if [ "${ENABLE_CODEQL_DEBUG}" = true ]; then
+            echo "Checking for failed extractions"
+            "\$command" bqrs decode "${DATABASE_PATH}/results/codeql/${LANGUAGE}-queries/Diagnostics/ExtractionErrors.bqrs"
+        fi
+
+        echo "Generating CSV of results"
+        "\$command" database interpret-results "${DATABASE_PATH}" --format=csv --output="codeql-scan-results-${LANGUAGE}.csv" "${QL_PACKS}"
+        echo "CSV of results generated"
+
+        echo "Generating Database Bundle"
+        "\$command" database bundle "${DATABASE_PATH}" --output "${DATABASE_BUNDLE}"
+        echo "Database Bundle generated"
+    """
+}

--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
@@ -132,32 +132,32 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
             if [ -z "${BUILD_COMMAND}" ]; then
                 echo "No build command, using default"
                 if [ "${INSTALL_CODEQL}" = true ]; then
-                    ./codeql/codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --source-root .
+                    ./codeql/codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root .
                 else
-                    codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --source-root .
+                    codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root .
                 fi
             else
                 echo "Build command specified, using '${BUILD_COMMAND}'"
                 if [ "${INSTALL_CODEQL}" = true ]; then
-                    ./codeql/codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
+                    ./codeql/codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
                 else
-                    codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
+                    codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
                 fi
             fi
         else
             if [ -z "${BUILD_COMMAND}" ]; then
                 echo "No build command, using default"
                 if [ "${INSTALL_CODEQL}" = true ]; then
-                    ./codeql/codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
+                    ./codeql/codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
                 else
-                    codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
+                    codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
                 fi
             else
                 echo "Build command specified, using '${BUILD_COMMAND}'"
                 if [ "${INSTALL_CODEQL}" = true ]; then
-                    ./codeql/codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
+                    ./codeql/codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
                 else
-                    codeql database create "${DATABASE_PATH}" --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
+                    codeql database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
                 fi
             fi
         fi
@@ -177,9 +177,9 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
 
         echo "Analyzing database"
         if [ "${INSTALL_CODEQL}" = true ]; then
-            ./codeql/codeql database analyze "${DATABASE_PATH}" --no-download --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
+            ./codeql/codeql database analyze "${DATABASE_PATH}" --no-download --threads 0 --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
         else
-            codeql database analyze "${DATABASE_PATH}" --no-download --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
+            codeql database analyze "${DATABASE_PATH}" --no-download --threads 0 --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
         fi
         echo "Database analyzed"
 

--- a/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
+++ b/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
@@ -1,0 +1,58 @@
+def call(repo, language, buildCommand) {
+    env.BUILD_COMMAND = buildCommand
+    env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql.yml"
+    env.DATABASE_PATH = sprintf("%s-%s", repo, language)
+    if(!env.ENABLE_DEBUG) {
+        env.ENABLE_DEBUG = false
+    }
+    env.LANGUAGE = language
+    if(env.LANGUAGE != "javascript" && env.LANGUAGE != "python" && env.LANGUAGE != "ruby") {
+        env.COMPILED_LANGUAGE = true
+    } else {
+        env.COMPILED_LANGUAGE = false
+    }
+
+    sh """
+        if [ "${ENABLE_DEBUG}" = true ]; then
+            set -x
+        else
+            set +x
+        fi
+
+        command="codeql"
+        if [ ! -x "\$(command -v \$command)" ]; then
+            echo "CodeQL CLI not found on PATH, checking if local copy exists"
+            if [ ! -f "${WORKSPACE}/codeql/codeql" ]; then
+                echo "CodeQL CLI not found in local copy, please add the CodeQL CLI to your PATH or use the 'InstallCodeQL' command to download it"
+                exit 1
+            fi
+            echo "Using local copy of CodeQL CLI"
+            command="${WORKSPACE}/codeql/codeql"
+        fi
+
+        echo "Initializing database"
+        if [ "${BUILD_COMMAND}" != "" ]; then
+            echo "Invoking build command: ${BUILD_COMMAND}"
+            if [ ! -f "${CONFIG_FILE}" ]; then
+                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
+            else
+                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
+            fi
+        elif [ "${COMPILED_LANGUAGE}" = "false" ]; then
+            echo "Invoking auto-builder for non-compiled language"
+            if [ ! -f "${CONFIG_FILE}" ]; then
+                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root .
+            else
+                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
+            fi
+        else
+            echo "Invoking build-tracing for compiled language"
+            if [ ! -f "${CONFIG_FILE}" ]; then
+                "\$command" database init "${DATABASE_PATH}" --language="${LANGUAGE}" --source-root . --begin-tracing
+            else
+                "\$command" database init "${DATABASE_PATH}" --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --begin-tracing
+            fi
+        fi
+        echo "Database initialized"
+    """
+}

--- a/jenkins/shared-libraries/linux/vars/InstallCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/InstallCodeQL.groovy
@@ -1,0 +1,46 @@
+def call(token) {
+    env.AUTHORIZATION_HEADER = sprintf("Authorization: token %s", token)
+    if(!env.ENABLE_DEBUG) {
+        env.ENABLE_DEBUG = false
+    }
+    env.GITHUB_TOKEN = token
+
+    sh '''
+        if [ "${ENABLE_DEBUG}" = true ]; then
+            set -x
+        else
+            set +x
+        fi
+
+        echo "Installing CodeQL"
+
+        echo "Retrieving latest CodeQL release"
+        if [ "${ENABLE_TLS_NO_VERIFY}" = true ]; then
+            id=\$(curl --insecure --silent --retry 3 --location \
+            --header "${AUTHORIZATION_HEADER}" \
+            --header "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/github/codeql-action/releases/latest" | jq -r .tag_name)
+
+            echo "Downloading CodeQL version '\$id'"
+            curl --insecure --silent --retry 3 --location --output "${WORKSPACE}/codeql.tgz" \
+            --header "${AUTHORIZATION_HEADER}" \
+            "https://github.com/github/codeql-action/releases/download/\$id/codeql-bundle-linux64.tar.gz"
+            tar -xf "${WORKSPACE}/codeql.tgz" --directory "${WORKSPACE}"
+            rm "${WORKSPACE}/codeql.tgz"
+        else
+            id=\$(curl --silent --retry 3 --location \
+            --header "${AUTHORIZATION_HEADER}" \
+            --header "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/github/codeql-action/releases/latest" | jq -r .tag_name)
+
+            echo "Downloading CodeQL version '\$id'"
+            curl --silent --retry 3 --location --output "${WORKSPACE}/codeql.tgz" \
+            --header "${AUTHORIZATION_HEADER}" \
+            "https://github.com/github/codeql-action/releases/download/\$id/codeql-bundle-linux64.tar.gz"
+            tar -xf "${WORKSPACE}/codeql.tgz" --directory "${WORKSPACE}"
+            rm "${WORKSPACE}/codeql.tgz"
+        fi
+
+        echo "CodeQL installed"
+    '''
+}

--- a/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
+++ b/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
@@ -1,0 +1,65 @@
+def call(org, repo, branch, language, token) {
+    env.AUTHORIZATION_HEADER = sprintf("Authorization: token %s", token)
+    if(branch == "") {
+        env.BRANCH = env.GIT_BRANCH
+    } else {
+        env.BRANCH = branch
+    }
+    env.DATABASE_BUNDLE = sprintf("%s-database.zip", language)
+    if(!env.ENABLE_DEBUG) {
+        env.ENABLE_DEBUG = false
+    }
+    env.GITHUB_TOKEN = token
+    env.LANGUAGE = language
+    env.ORG = org
+    env.REPO = repo
+    env.REF = sprintf("refs/heads/%s", env.BRANCH)
+    if(env.CHANGE_ID) {
+        env.REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
+    }
+
+    sh '''
+        if [ "${ENABLE_DEBUG}" = true ]; then
+            set -x
+        else
+            set +x
+        fi
+
+        command="codeql"
+        if [ ! -x "\$(command -v \$command)" ]; then
+            echo "CodeQL CLI not found on PATH, checking if local copy exists"
+            if [ ! -f "${WORKSPACE}/codeql/codeql" ]; then
+                echo "CodeQL CLI not found in local copy, please add the CodeQL CLI to your PATH or use the 'InstallCodeQL' command to download it"
+                exit 1
+            fi
+            echo "Using local copy of CodeQL CLI"
+            command="${WORKSPACE}/codeql/codeql"
+        fi
+
+        echo "Uploading SARIF file"
+        commit=\$(git rev-parse HEAD)
+        "\$command" github upload-results \
+        --repository="${ORG}/${REPO}" \
+        --ref="${REF}" \
+        --commit="\$commit" \
+        --sarif="${SARIF_FILE}"
+        echo "SARIF file uploaded"
+
+        echo "Uploading Database Bundle"
+        sizeInBytes=`stat --printf="%s" ${DATABASE_BUNDLE}`
+        if [ "${ENABLE_TLS_NO_VERIFY}" = true ]; then
+            curl --insecure --http1.0 --silent --retry 3 -X POST -H "Content-Type: application/zip" \
+            -H "Content-Length: \$sizeInBytes" \
+            -H "${AUTHORIZATION_HEADER}" \
+            -T "${DATABASE_BUNDLE}" \
+            "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+        else
+            curl --http1.0 --silent --retry 3 -X POST -H "Content-Type: application/zip" \
+            -H "Content-Length: \$sizeInBytes" \
+            -H "${AUTHORIZATION_HEADER}" \
+            -T "${DATABASE_BUNDLE}" \
+            "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+        fi
+        echo "Database Bundle uploaded"
+    '''
+}

--- a/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
@@ -67,6 +67,8 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
             Exit 6
         }
 
+
+        \$ProgressPreference = 'SilentlyContinue'
         if("\$Env:INSTALL_CODEQL" -eq "false") {
             Write-Output "Skipping installation of CodeQL"
         } else {
@@ -108,32 +110,32 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
             if ("\$Env:BUILD_COMMAND" -eq "") {
                 Write-Output "No build command specified, using default"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --source-root .
+                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root .
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --source-root .
+                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root .
                 }
             } else {
                 Write-Output "Build command specified, using '\$Env:BUILD_COMMAND'"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
                 }
             }
         } else {
             if ("\$Env:BUILD_COMMAND" -eq "") {
                 Write-Output "No build command specified, using default"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
+                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
+                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
                 }
             } else {
                 Write-Output "Build command specified, using '\$Env:BUILD_COMMAND'"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
                 }
             }
         }
@@ -153,9 +155,9 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
 
         Write-Output "Analyzing database"
         if("\$Env:INSTALL_CODEQL" -eq "true") {
-            .\\codeql\\codeql database analyze --download "\$Env:DATABASE_PATH" --sarif-category "ois-\$Env:LANGUAGE\$Env:SEP\$Env:CWD" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
+            .\\codeql\\codeql database analyze --download "\$Env:DATABASE_PATH" --threads 0 --sarif-category "ois-\$Env:LANGUAGE\$Env:SEP\$Env:CWD" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
         } else {
-            codeql database analyze --download "\$Env:DATABASE_PATH" --sarif-category "ois-\$Env:LANGUAGE" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
+            codeql database analyze --download "\$Env:DATABASE_PATH" --threads 0 --sarif-category "ois-\$Env:LANGUAGE" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
         }
         Write-Output "Database analyzed"
         Write-Output "Generating CSV of results"


### PR DESCRIPTION
This pull request introduces a set of Linux Shared Libraries allowing Jenkins users to execute CodeQL scans during their normal build process. This differs from the use of the `ExecuteCodeQL()` function in that users will no longer have to perform separate builds to perform CodeQL scans but can instead use CodeQL [trace-commands](https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#specifying-build-commands) or [build-tracing](https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#using-indirect-build-tracing) to invoke their build processes in CI once.

The following Shared Library Functions are introduced:
- `InstallCodeQL()`
  - Allows users to install CodeQL at runtime
- `InitializeCodeQLDatabase()`
  - Depending on whether users are scanning a non-compiled language, whether they intend to use `trace-commands`, or `build-tracing` an appropriate database is created
- `AnalyzeCodeQLDatabase()`
  - Depending on whether users are analyzing a non-compiled language, whether the database was created using `trace-commands`, or using `build-tracing` the database is properly analyzed
- `UploadResults()`
  - Uploads the CodeQL SARIF file and the CodeQL database to GitHub