### PR TITLE
Correct path to CodeQL Config File

### DIFF
--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
@@ -6,7 +6,7 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
         env.BRANCH = branch
     }
     env.BUILD_COMMAND = buildCommand
-    env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql.yml"
+    env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql-config.yml"
     env.DATABASE_BUNDLE = sprintf("%s-database.zip", language)
     env.DATABASE_PATH = sprintf("%s-%s", repo, language)
     if(!env.ENABLE_DEBUG) {

--- a/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
+++ b/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
@@ -1,6 +1,6 @@
 def call(repo, language, buildCommand) {
     env.BUILD_COMMAND = buildCommand
-    env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql.yml"
+    env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql-config.yml"
     env.DATABASE_PATH = sprintf("%s-%s", repo, language)
     if(!env.ENABLE_DEBUG) {
         env.ENABLE_DEBUG = false


### PR DESCRIPTION
Fix a bug where the CONFIG_FILE property was incorrectly pointing to codeql.yml instead of codeql-config.yml