### PR TITLE
Provide an option to specify RAM and THREADS values

### DIFF
--- a/jenkins/shared-libraries/linux/vars/AnalyzeCodeQLDatabase.groovy
+++ b/jenkins/shared-libraries/linux/vars/AnalyzeCodeQLDatabase.groovy
@@ -1,4 +1,14 @@
 def call(repo, language) {
+    if(!env.CODEQL_RAM) {
+        env.CODEQL_RAM_FLAG = ""
+    } else {
+        env.CODEQL_RAM_FLAG = sprintf("--ram %s", env.CODEQL_RAM.trim())
+    }
+    if(!env.CODEQL_THREADS) {
+        env.CODEQL_THREADS_FLAG = "--threads 0"
+    } else {
+        env.CODEQL_THREADS_FLAG = sprintf("--threads %s", env.CODEQL_THREADS.trim())
+    }
     env.DATABASE_BUNDLE = sprintf("%s-database.zip", language)
     env.DATABASE_PATH = sprintf("%s-%s", repo, language)
     if(!env.ENABLE_DEBUG) {
@@ -53,7 +63,7 @@ def call(repo, language) {
         echo "The SARIF category has been configured to ois-${LANGUAGE}\${SEP}\${SUBDIR}"
 
         echo "Analyzing database"
-        "\$command" database analyze "${DATABASE_PATH}" --no-download --threads 0 --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
+        "\$command" database analyze "${DATABASE_PATH}" --no-download ${CODEQL_THREADS_FLAG} ${CODEQL_RAM_FLAG} --sarif-category "ois-${LANGUAGE}\${SEP}\${SUBDIR}" --format sarif-latest --output "${SARIF_FILE}" "${QL_PACKS}"
         echo "Database analyzed"
 
         if [ "${ENABLE_CODEQL_DEBUG}" = true ]; then

--- a/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
+++ b/jenkins/shared-libraries/linux/vars/InitializeCodeQLDatabase.groovy
@@ -1,5 +1,15 @@
 def call(repo, language, buildCommand) {
     env.BUILD_COMMAND = buildCommand
+    if(!env.CODEQL_RAM) {
+        env.CODEQL_RAM_FLAG = ""
+    } else {
+        env.CODEQL_RAM_FLAG = sprintf("--ram %s", env.CODEQL_RAM.trim())
+    }
+    if(!env.CODEQL_THREADS) {
+        env.CODEQL_THREADS_FLAG = "--threads 0"
+    } else {
+        env.CODEQL_THREADS_FLAG = sprintf("--threads %s", env.CODEQL_THREADS.trim())
+    }
     env.CONFIG_FILE = "${env.WORKSPACE}/.github/codeql-config.yml"
     env.DATABASE_PATH = sprintf("%s-%s", repo, language)
     if(!env.ENABLE_DEBUG) {
@@ -34,16 +44,16 @@ def call(repo, language, buildCommand) {
         if [ "${BUILD_COMMAND}" != "" ]; then
             echo "Invoking build command: ${BUILD_COMMAND}"
             if [ ! -f "${CONFIG_FILE}" ]; then
-                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
+                "\$command" database create "${DATABASE_PATH}" ${CODEQL_THREADS_FLAG} ${CODEQL_RAM_FLAG} --language="${LANGUAGE}" --source-root . --command="${BUILD_COMMAND}"
             else
-                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
+                "\$command" database create "${DATABASE_PATH}" ${CODEQL_THREADS_FLAG} ${CODEQL_RAM_FLAG} --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root . --command="${BUILD_COMMAND}"
             fi
         elif [ "${COMPILED_LANGUAGE}" = "false" ]; then
             echo "Invoking auto-builder for non-compiled language"
             if [ ! -f "${CONFIG_FILE}" ]; then
-                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --source-root .
+                "\$command" database create "${DATABASE_PATH}" ${CODEQL_THREADS_FLAG} ${CODEQL_RAM_FLAG} --language="${LANGUAGE}" --source-root .
             else
-                "\$command" database create "${DATABASE_PATH}" --threads 0 --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
+                "\$command" database create "${DATABASE_PATH}" ${CODEQL_THREADS_FLAG} ${CODEQL_RAM_FLAG} --language="${LANGUAGE}" --codescanning-config "${CONFIG_FILE}" --source-root .
             fi
         else
             echo "Invoking build-tracing for compiled language"

--- a/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
@@ -9,6 +9,16 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
         env.BRANCH = Branch
     }
     env.BUILD_COMMAND = BuildCommand
+    if(!env.CODEQL_RAM) {
+        env.CODEQL_RAM_FLAG = ""
+    } else {
+        env.CODEQL_RAM_FLAG = sprintf("--ram %s", env.CODEQL_RAM.trim())
+    }
+    if(!env.CODEQL_THREADS) {
+        env.CODEQL_THREADS_FLAG = "--threads 0"
+    } else {
+        env.CODEQL_THREADS_FLAG = sprintf("--threads %s", env.CODEQL_THREADS.trim())
+    }
     env.CONFIG_FILE = "${env.WORKSPACE}\\.github\\codeql-config.yml"
     env.DATABASE_BUNDLE = sprintf("%s-database.zip", Language)
     env.DATABASE_PATH = sprintf("%s-%s", Repo, Language)
@@ -110,32 +120,32 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
             if ("\$Env:BUILD_COMMAND" -eq "") {
                 Write-Output "No build command specified, using default"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root .
+                    Invoke-Expression ".\\codeql\\codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --source-root ."
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root .
+                    Invoke-Expression "codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --source-root ."
                 }
             } else {
                 Write-Output "Build command specified, using '\$Env:BUILD_COMMAND'"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    Invoke-Expression ".\\codeql\\codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --source-root . --command '\$Env:BUILD_COMMAND'"
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    Invoke-Expression "codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --source-root . --command '\$Env:BUILD_COMMAND'"
                 }
             }
         } else {
             if ("\$Env:BUILD_COMMAND" -eq "") {
                 Write-Output "No build command specified, using default"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
+                    Invoke-Expression ".\\codeql\\codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --codescanning-config '\$Env:CONFIG_FILE' --source-root ."
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root .
+                    Invoke-Expression "codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --codescanning-config '\$Env:CONFIG_FILE' --source-root ."
                 }
             } else {
                 Write-Output "Build command specified, using '\$Env:BUILD_COMMAND'"
                 if("\$Env:INSTALL_CODEQL" -eq "true") {
-                    .\\codeql\\codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    Invoke-Expression ".\\codeql\\codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --codescanning-config '\$Env:CONFIG_FILE' --source-root . --command '\$Env:BUILD_COMMAND'"
                 } else {
-                    codeql database create "\$Env:DATABASE_PATH" --threads 0 --language "\$Env:LANGUAGE" --codescanning-config "\$Env:CONFIG_FILE" --source-root . --command "\$Env:BUILD_COMMAND"
+                    Invoke-Expression "codeql database create '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --language '\$Env:LANGUAGE' --codescanning-config '\$Env:CONFIG_FILE' --source-root . --command '\$Env:BUILD_COMMAND'"
                 }
             }
         }
@@ -155,16 +165,16 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
 
         Write-Output "Analyzing database"
         if("\$Env:INSTALL_CODEQL" -eq "true") {
-            .\\codeql\\codeql database analyze --no-download "\$Env:DATABASE_PATH" --threads 0 --sarif-category "ois-\$Env:LANGUAGE\$Env:SEP\$Env:CWD" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
+            Invoke-Expression ".\\codeql\\codeql database analyze --no-download '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --sarif-category 'ois-\$Env:LANGUAGE\$Env:SEP\$Env:CWD' --format sarif-latest --output '\$Env:SARIF_FILE' '\$Env:QL_PACKS'"
         } else {
-            codeql database analyze --no-download "\$Env:DATABASE_PATH" --threads 0 --sarif-category "ois-\$Env:LANGUAGE" --format sarif-latest --output "\$Env:SARIF_FILE" "\$Env:QL_PACKS"
+            Invoke-Expression "codeql database analyze --no-download '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG \$Env:CODEQL_RAM_FLAG --sarif-category 'ois-\$Env:LANGUAGE' --format sarif-latest --output '\$Env:SARIF_FILE' '\$Env:QL_PACKS'"
         }
         Write-Output "Database analyzed"
         Write-Output "Generating CSV of results"
         if("\$Env:INSTALL_CODEQL" -eq "true") {
-            .\\codeql\\codeql database interpret-results "\$Env:DATABASE_PATH" --threads 0 --format=csv --output="codeql-scan-results-\$Env:LANGUAGE.csv" "\$Env:QL_PACKS"
+            Invoke-Expression ".\\codeql\\codeql database interpret-results '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG --format=csv --output='codeql-scan-results-\$Env:LANGUAGE.csv' '\$Env:QL_PACKS'"
         } else {
-            codeql database interpret-results "\$Env:DATABASE_PATH" --threads 0 --format=csv --output="codeql-scan-results-\$Env:LANGUAGE.csv" "\$Env:QL_PACKS"
+            Invoke-Expression "codeql database interpret-results '\$Env:DATABASE_PATH' \$Env:CODEQL_THREADS_FLAG --format=csv --output='codeql-scan-results-\$Env:LANGUAGE.csv' '\$Env:QL_PACKS'"
         }
         Write-Output "CSV of results generated"
 


### PR DESCRIPTION
This pull requests adds the ability for users to specify values for the number of threads and the amount of RAM for CodeQL to use while performing Actions. Since the CodeQL CLI is written in Java, the Java Virtual Machine has a tendency to to exceed its default heap values and cause `Out of Memory` failures.

This will be following up with a technote in the SWA Wiki on how to set these values, but the net-net is, if a user does not set any values, all available threads and the default CodeQL RAM values will be used. If a user sets either the `CODEQL_THREADS` or `CODEQL_RAM` environment variables, those values will be passed to the CodeQL `--threads` and `--ram` flags.