### PR TITLE
Fix support for OSX

### DIFF
--- a/.github/workflows/codeql-pull-request.yml
+++ b/.github/workflows/codeql-pull-request.yml
@@ -19,6 +19,7 @@ jobs:
           - go
           - javascript
         runner:
+          - macos-latest-xlarge
           - ubuntu-8-cores-latest
           - windows-8-cores-latest
         config-file:

--- a/codeql-analysis/action.yml
+++ b/codeql-analysis/action.yml
@@ -54,6 +54,7 @@ runs:
       uses: department-of-veterans-affairs/codeql-tools/validate-emass-json@main
 
     - name: Initialize CodeQL
+      id: init
       uses: github/codeql-action/init@v2
       with:
         config: ${{ inputs.config }}
@@ -108,9 +109,10 @@ runs:
         category: ois-${{ inputs.language }}-${{ inputs.path }}
 
     - name: Generate CodeQL Results CSV
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       shell: bash
       run: |
+        set -x
         database_path="$temp/codeql-scan-results-$language.csv"
         echo "Generating CodeQL Results CSV at $database_path"
         if [[ ! -v codeql ]]; then
@@ -118,6 +120,18 @@ runs:
         else
           codeql database interpret-results $database --format=csv --output="$database_path"
         fi
+      env:
+        language: ${{ inputs.language }}
+        database: ${{ runner.temp }}/codeql_databases/${{ inputs.language }}
+        temp: ${{ runner.temp }}
+
+    - name: Generate CodeQL Results CSV
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        database_path="$temp/codeql-scan-results-$language.csv"
+        echo "Generating CodeQL Results CSV at $database_path"
+        ${{ steps.init.outputs.codeql-path }} database interpret-results $database --format=csv --output="$database_path"
       env:
         language: ${{ inputs.language }}
         database: ${{ runner.temp }}/codeql_databases/${{ inputs.language }}


### PR DESCRIPTION
This pull request primarily focuses on updating the workflow configuration and action setup for CodeQL analysis. The most important changes include adding a new runner in the workflow configuration, initializing CodeQL with a unique ID, and modifying the conditions for generating CodeQL Results CSV based on the runner's operating system.

Workflow configuration changes:

* <a href="diffhunk://#diff-2fff1f96dbd053fc8b4a84548f88b3dc607241c328666dcca321dae805917425R22">`.github/workflows/codeql-pull-request.yml`</a>: A new runner, `macos-latest-xlarge`, has been added to the list of runners. This change allows CodeQL analysis to be performed on a macOS environment with the latest specifications.

Action setup changes:

* <a href="diffhunk://#diff-e219d1eac78ac47645c01f20f84695ee9d5e83232df177d89493166799da8cd7R57">`codeql-analysis/action.yml`</a>: The CodeQL initialization step now has a unique ID, `init`. This ID can be used to reference the outputs of this step in subsequent steps.
* <a href="diffhunk://#diff-e219d1eac78ac47645c01f20f84695ee9d5e83232df177d89493166799da8cd7L111-R115">`codeql-analysis/action.yml`</a>: The condition for generating CodeQL Results CSV has been changed from `runner.os != 'Windows'` to `runner.os == 'Linux'`. This change ensures that the CSV generation only runs on Linux environments.
* <a href="diffhunk://#diff-e219d1eac78ac47645c01f20f84695ee9d5e83232df177d89493166799da8cd7R128-R139">`codeql-analysis/action.yml`</a>: A new step has been added to generate CodeQL Results CSV specifically for macOS environments. This ensures that the CSV generation is correctly handled for different operating systems.