### PR TITLE
Allow users to select extended query suite

### DIFF
--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
@@ -43,9 +43,9 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
-    if(env.ENABLED_EXTENDED_QUERIES) {
+    if(env.ENABLE_EXTENDED_QUERIES) {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
-    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+    } else if(env.ENABLE_EXTENDED_QUERIES &&  env.ENABLE_EXTENDED_QUERIES == "true") {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
     }
     if(!env.UPLOAD_RESULTS) {

--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
@@ -43,6 +43,11 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
+    if(env.ENABLED_EXTENDED_QUERIES) {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    }
     if(!env.UPLOAD_RESULTS) {
         env.UPLOAD_RESULTS = true
     } else if(env.UPLOAD_RESULTS && env.UPLOAD_RESULTS == "true") {

--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
@@ -43,9 +43,9 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
-    if(env.ENABLED_EXTENDED_QUERIES) {
+    if(env.ENABLE_EXTENDED_QUERIES) {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
-    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+    } else if(env.ENABLE_EXTENDED_QUERIES &&  env.ENABLE_EXTENDED_QUERIES == "true") {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
     }
     if(!env.UPLOAD_RESULTS) {

--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
@@ -43,6 +43,11 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
+    if(env.ENABLED_EXTENDED_QUERIES) {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    }
     if(!env.UPLOAD_RESULTS) {
         env.UPLOAD_RESULTS = true
     } else if(env.UPLOAD_RESULTS && env.UPLOAD_RESULTS == "true") {

--- a/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
@@ -41,6 +41,11 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
     env.SARIF_FILE = sprintf("%s-%s.sarif", Repo, Language)
     env.UPLOAD_URL = sprintf("https://uploads.github.com/repos/%s/%s/code-scanning/codeql/databases/%s?name=%s", Org, Repo, Language, env.DATABASE_BUNDLE)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
+    if(env.ENABLED_EXTENDED_QUERIES) {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+        env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
+    }
     if(!env.UPLOAD_RESULTS) {
         env.UPLOAD_RESULTS = true
     } else if(env.UPLOAD_RESULTS && env.UPLOAD_RESULTS == "true") {

--- a/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy
@@ -41,9 +41,9 @@ def call(Org, Repo, Branch, Language, BuildCommand, Token, InstallCodeQL) {
     env.SARIF_FILE = sprintf("%s-%s.sarif", Repo, Language)
     env.UPLOAD_URL = sprintf("https://uploads.github.com/repos/%s/%s/code-scanning/codeql/databases/%s?name=%s", Org, Repo, Language, env.DATABASE_BUNDLE)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
-    if(env.ENABLED_EXTENDED_QUERIES) {
+    if(env.ENABLE_EXTENDED_QUERIES) {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
-    } else if(env.ENABLED_EXTENDED_QUERIES &&  env.ENABLED_EXTENDED_QUERIES == "true") {
+    } else if(env.ENABLE_EXTENDED_QUERIES &&  env.ENABLE_EXTENDED_QUERIES == "true") {
         env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-security-extended.qls", language, language)
     }
     if(!env.UPLOAD_RESULTS) {


### PR DESCRIPTION
This pull request primarily introduces changes to the `ExecuteCodeQL.groovy`, `ExecuteCodeQLWGet.groovy`, and `ExecuteCodeQL.groovy` files in the `jenkins/shared-libraries` directory. These changes add a new condition to check the `ENABLE_EXTENDED_QUERIES` environment variable and modify the `QL_PACKS` environment variable accordingly. This allows for the use of extended security queries in the CodeQL analysis.

Changes in CodeQL execution:

* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy`](diffhunk://#diff-f12283cfd99e3b6d1e0e18d6eb146758fc964600433207fde622a7f9e6507b7bR46-R50): Added a condition to check if `ENABLE_EXTENDED_QUERIES` is set. If it is, `QL_PACKS` is updated to use extended security queries.
* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy`](diffhunk://#diff-db8df6a8b89eb48daa6204a57f1fd0ed890d11f91cf79af769756b654a2b6a7bR46-R50): Similar to the above, added a condition to check for `ENABLE_EXTENDED_QUERIES` and update `QL_PACKS` accordingly.
* [`jenkins/shared-libraries/windows/vars/ExecuteCodeQL.groovy`](diffhunk://#diff-bee8fe88af6bd1577a26965067b058753f97ae45ba71b850fc11202b3c76f2bdR44-R48): Implemented the same changes as in the Linux variants of the file, checking for `ENABLE_EXTENDED_QUERIES` and updating `QL_PACKS` to use extended security queries if the condition is met.