### PR TITLE
Prefix common environment variables

### DIFF
--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy
@@ -35,11 +35,11 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     if(env.LANGUAGE == "swift") {
         env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT = true
     }
-    env.ORG = org
-    env.REPO = repo
-    env.REF = sprintf("refs/heads/%s", env.BRANCH)
+    env.CT_ORG = org
+    env.CT_REPO = repo
+    env.CT_REF = sprintf("refs/heads/%s", env.BRANCH)
     if(env.CHANGE_ID) {
-        env.REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
+        env.CT_REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
@@ -197,8 +197,8 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
             echo "Uploading SARIF file"
             commit=\$(git rev-parse HEAD)
             "\$command" github upload-results \
-            --repository="${ORG}/${REPO}" \
-            --ref="${REF}" \
+            --repository="${CT_ORG}/${CT_REPO}" \
+            --ref="${CT_REF}" \
             --commit="\$commit" \
             --sarif="${SARIF_FILE}"
             echo "SARIF file uploaded"
@@ -224,13 +224,13 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
                 -H "Content-Length: \$sizeInBytes" \
                 -H "${AUTHORIZATION_HEADER}" \
                 -T "${DATABASE_BUNDLE}" \
-                "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+                "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
             else
                 curl --http1.0 --silent --retry 3 -X POST -H "Content-Type: application/zip" \
                 -H "Content-Length: \$sizeInBytes" \
                 -H "${AUTHORIZATION_HEADER}" \
                 -T "${DATABASE_BUNDLE}" \
-                "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+                "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
             fi
             echo "Database Bundle uploaded"
         fi

--- a/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
+++ b/jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy
@@ -35,11 +35,11 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
     if(env.LANGUAGE == "swift") {
         env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT = true
     }
-    env.ORG = org
-    env.REPO = repo
-    env.REF = sprintf("refs/heads/%s", env.BRANCH)
+    env.CT_ORG = org
+    env.CT_REPO = repo
+    env.CT_REF = sprintf("refs/heads/%s", env.BRANCH)
     if(env.CHANGE_ID) {
-        env.REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
+        env.CT_REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
     }
     env.SARIF_FILE = sprintf("%s-%s.sarif", repo, language)
     env.QL_PACKS = sprintf("codeql/%s-queries:codeql-suites/%s-code-scanning.qls", language, language)
@@ -207,8 +207,8 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
             echo "Uploading SARIF file"
             commit=\$(git rev-parse HEAD)
             "\$command" github upload-results \
-            --repository="${ORG}/${REPO}" \
-            --ref="${REF}" \
+            --repository="${CT_ORG}/${CT_REPO}" \
+            --ref="${CT_REF}" \
             --commit="\$commit" \
             --sarif="${SARIF_FILE}"
             echo "SARIF file uploaded"
@@ -230,9 +230,9 @@ def call(org, repo, branch, language, buildCommand, token, installCodeQL) {
             echo "Uploading Database Bundle"
             sizeInBytes=`stat --printf="%s" ${DATABASE_BUNDLE}`
             if [ "${ENABLE_TLS_NO_VERIFY}" = true ]; then
-                wget --no-check-certificate --quiet --tries=3 --method=POST --header="Content-Type: application/zip" --header="Content-Length: \$sizeInBytes" --header="${AUTHORIZATION_HEADER}" --body-file="${DATABASE_BUNDLE}" -O- "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+                wget --no-check-certificate --quiet --tries=3 --method=POST --header="Content-Type: application/zip" --header="Content-Length: \$sizeInBytes" --header="${AUTHORIZATION_HEADER}" --body-file="${DATABASE_BUNDLE}" -O- "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
             else
-                wget --quiet --tries=3 --method=POST --header="Content-Type: application/zip" --header="Content-Length: \$sizeInBytes" --header="${AUTHORIZATION_HEADER}" --body-file="${DATABASE_BUNDLE}" -O- "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+                wget --quiet --tries=3 --method=POST --header="Content-Type: application/zip" --header="Content-Length: \$sizeInBytes" --header="${AUTHORIZATION_HEADER}" --body-file="${DATABASE_BUNDLE}" -O- "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
             fi
             echo "Database Bundle uploaded"
         fi

--- a/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
+++ b/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
@@ -11,11 +11,11 @@ def call(org, repo, branch, language, token) {
     }
     env.GITHUB_TOKEN = token
     env.LANGUAGE = language
-    env.ORG = org
-    env.REPO = repo
-    env.REF = sprintf("refs/heads/%s", env.BRANCH)
+    env.CT_TOOLS = org
+    env.CT_REPO = repo
+    env.CT_REF = sprintf("refs/heads/%s", env.BRANCH)
     if(env.CHANGE_ID) {
-        env.REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
+        env.CT_REF = sprintf("refs/pull/%s/head", env.CHANGE_ID)
     }
 
     sh '''
@@ -39,8 +39,8 @@ def call(org, repo, branch, language, token) {
         echo "Uploading SARIF file"
         commit=\$(git rev-parse HEAD)
         "\$command" github upload-results \
-        --repository="${ORG}/${REPO}" \
-        --ref="${REF}" \
+        --repository="${CT_TOOLS}/${CT_REPO}" \
+        --ref="${CT_REF}" \
         --commit="\$commit" \
         --sarif="${SARIF_FILE}"
         echo "SARIF file uploaded"
@@ -52,13 +52,13 @@ def call(org, repo, branch, language, token) {
             -H "Content-Length: \$sizeInBytes" \
             -H "${AUTHORIZATION_HEADER}" \
             -T "${DATABASE_BUNDLE}" \
-            "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+            "https://uploads.github.com/repos/$CT_TOOLS/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
         else
             curl --http1.0 --silent --retry 3 -X POST -H "Content-Type: application/zip" \
             -H "Content-Length: \$sizeInBytes" \
             -H "${AUTHORIZATION_HEADER}" \
             -T "${DATABASE_BUNDLE}" \
-            "https://uploads.github.com/repos/$ORG/$REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+            "https://uploads.github.com/repos/$CT_TOOLS/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
         fi
         echo "Database Bundle uploaded"
     '''

--- a/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
+++ b/jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy
@@ -11,7 +11,7 @@ def call(org, repo, branch, language, token) {
     }
     env.GITHUB_TOKEN = token
     env.LANGUAGE = language
-    env.CT_TOOLS = org
+    env.CT_ORG = org
     env.CT_REPO = repo
     env.CT_REF = sprintf("refs/heads/%s", env.BRANCH)
     if(env.CHANGE_ID) {
@@ -39,7 +39,7 @@ def call(org, repo, branch, language, token) {
         echo "Uploading SARIF file"
         commit=\$(git rev-parse HEAD)
         "\$command" github upload-results \
-        --repository="${CT_TOOLS}/${CT_REPO}" \
+        --repository="${CT_ORG}/${CT_REPO}" \
         --ref="${CT_REF}" \
         --commit="\$commit" \
         --sarif="${SARIF_FILE}"
@@ -52,13 +52,13 @@ def call(org, repo, branch, language, token) {
             -H "Content-Length: \$sizeInBytes" \
             -H "${AUTHORIZATION_HEADER}" \
             -T "${DATABASE_BUNDLE}" \
-            "https://uploads.github.com/repos/$CT_TOOLS/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+            "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
         else
             curl --http1.0 --silent --retry 3 -X POST -H "Content-Type: application/zip" \
             -H "Content-Length: \$sizeInBytes" \
             -H "${AUTHORIZATION_HEADER}" \
             -T "${DATABASE_BUNDLE}" \
-            "https://uploads.github.com/repos/$CT_TOOLS/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
+            "https://uploads.github.com/repos/$CT_ORG/$CT_REPO/code-scanning/codeql/databases/${LANGUAGE}?name=${DATABASE_BUNDLE}"
         fi
         echo "Database Bundle uploaded"
     '''


### PR DESCRIPTION
This pull request primarily involves changes to environment variable names and their usage in several groovy scripts under the `jenkins/shared-libraries/linux/vars/` directory. The environment variables `ORG`, `REPO`, and `REF` have been renamed to `CT_ORG`, `CT_REPO`, and `CT_REF`, respectively. These changes have been made consistently across all the scripts and their usages.

The changes can be grouped as follows:

Environment variable renaming:

* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy`](diffhunk://#diff-f12283cfd99e3b6d1e0e18d6eb146758fc964600433207fde622a7f9e6507b7bL38-R42): Renamed `ORG` to `CT_ORG`, `REPO` to `CT_REPO`, and `REF` to `CT_REF` in the `call` function.
* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy`](diffhunk://#diff-db8df6a8b89eb48daa6204a57f1fd0ed890d11f91cf79af769756b654a2b6a7bL38-R42): Renamed `ORG` to `CT_ORG`, `REPO` to `CT_REPO`, and `REF` to `CT_REF` in the `call` function.
* [`jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy`](diffhunk://#diff-90deb0ed282a22e6f6c2719a632bcc9ef48d45f4e542ebee10ffb7decd536f5eL14-R18): Renamed `ORG` to `CT_ORG`, `REPO` to `CT_REPO`, and `REF` to `CT_REF` in the `call` function.

Updates to method calls and URLs:

* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQL.groovy`](diffhunk://#diff-f12283cfd99e3b6d1e0e18d6eb146758fc964600433207fde622a7f9e6507b7bL200-R201): Updated the repository and reference parameters in the `github upload-results` command and the URL for uploading to GitHub in the `call` function to use the new environment variable names. [[1]](diffhunk://#diff-f12283cfd99e3b6d1e0e18d6eb146758fc964600433207fde622a7f9e6507b7bL200-R201) [[2]](diffhunk://#diff-f12283cfd99e3b6d1e0e18d6eb146758fc964600433207fde622a7f9e6507b7bL227-R233)
* [`jenkins/shared-libraries/linux/vars/ExecuteCodeQLWGet.groovy`](diffhunk://#diff-db8df6a8b89eb48daa6204a57f1fd0ed890d11f91cf79af769756b654a2b6a7bL210-R211): Updated the repository and reference parameters in the `github upload-results` command and the URL for uploading to GitHub in the `call` function to use the new environment variable names. [[1]](diffhunk://#diff-db8df6a8b89eb48daa6204a57f1fd0ed890d11f91cf79af769756b654a2b6a7bL210-R211) [[2]](diffhunk://#diff-db8df6a8b89eb48daa6204a57f1fd0ed890d11f91cf79af769756b654a2b6a7bL233-R235)
* [`jenkins/shared-libraries/linux/vars/UploadCodeQLResults.groovy`](diffhunk://#diff-90deb0ed282a22e6f6c2719a632bcc9ef48d45f4e542ebee10ffb7decd536f5eL42-R43): Updated the repository and reference parameters in the `github upload-results` command and the URL for uploading to GitHub in the `call` function to use the new environment variable names. [[1]](diffhunk://#diff-90deb0ed282a22e6f6c2719a632bcc9ef48d45f4e542ebee10ffb7decd536f5eL42-R43) [[2]](diffhunk://#diff-90deb0ed282a22e6f6c2719a632bcc9ef48d45f4e542ebee10ffb7decd536f5eL55-R61)